### PR TITLE
[16.0][FIX] account_asset_management: Do not create asset for CABA moves

### DIFF
--- a/account_asset_management/models/account_move.py
+++ b/account_asset_management/models/account_move.py
@@ -91,6 +91,8 @@ class AccountMove(models.Model):
     def _post(self, soft=True):
         ret_val = super()._post(soft=soft)
         for move in self:
+            if move.tax_cash_basis_origin_move_id: #Do not create assets when it is a CABA move
+                continue
             for aml in move.line_ids.filtered(
                 lambda line: line.asset_profile_id and not line.tax_line_id
             ):


### PR DESCRIPTION
When an invoice is reconciled on a Cash Basis environment new move with the same lines of the Invoice is created. All content on lines is copied, asset_profile_id too.

As far as asset have been created by invoice this second move don't have to create a second asset. This change allows to ignore asset creation when a CABA move is posted.